### PR TITLE
add extent4_type for epi-based fmap

### DIFF
--- a/bids2nda/main.py
+++ b/bids2nda/main.py
@@ -245,6 +245,8 @@ def run(args):
         dict_append(image03_dict, 'image_extent4', image_extent4)
         if suffix == "bold":
             extent4_type = "time"
+        elif description == "epi" and len(nii.shape) == 4:
+            extent4_type = "time"
         elif suffix == "dwi":
             extent4_type = "diffusion weighting"
         else:


### PR DESCRIPTION
EPI based fieldmaps (reverse phase encode images) can have a time dimension. Currently, *_epi.nii.gz files are not specified to have `extent4_type` "time", this should fix that - if there are multiple image frames. 

