### PR TITLE
Adding scan type for FLAIR

### DIFF
--- a/bids2nda/main.py
+++ b/bids2nda/main.py
@@ -136,6 +136,7 @@ def run(args):
                            "PD": "MR structural (PD)",
                            #"MR structural(FSPGR)",
                            "T2w": "MR structural (T2)",
+                           "FLAIR": "FLAIR",
                            "FLASH": "MR structural (FLASH)",
                            #PET;
                             #ASL;


### PR DESCRIPTION
This adds mapping for bids FLAIR prefix to NDA image03 SCAN_TYPE field with value of FLAIR.