### PR TITLE
BF: convert years to months BEFORE rounding and casting to int

### DIFF
--- a/bids2nda/main.py
+++ b/bids2nda/main.py
@@ -193,7 +193,7 @@ def run(args):
         ndar_date = sdate[1] + "/" + sdate[2].split("T")[0] + "/" + sdate[0]
         dict_append(image03_dict, 'interview_date', ndar_date)
 
-        interview_age = int(round(list(participants_df[participants_df.participant_id == "sub-" + sub].age)[0], 0))*12
+        interview_age = int(round(list(participants_df[participants_df.participant_id == "sub-" + sub].age)[0]*12, 0))
         dict_append(image03_dict, 'interview_age', interview_age)
 
         sex = list(participants_df[participants_df.participant_id == "sub-" + sub].sex)[0]


### PR DESCRIPTION
Otherwise we would covert only full years, but NIH wants month-precision.

https://nda.nih.gov/data_structure.html?short_name=image03  says:
Age in months at the time of the interview/test/sampling/imaging.
Age is rounded to chronological month. If the research participant is 15-days-old at time of interview, the appropriate value would be 0 months. If the participant is 16-days-old, the value would be 1 month.