### PR TITLE
docs: describe prerequisite files with many links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BIDS2NDA
-Extract NIMH Data Archive compatible metadata from Brain Imaging Data Structure (BIDS) compatible datasets
+Extract [NIMH Data Archive](https://nda.nih.gov/) compatible metadata from [Brain Imaging Data Structure (BIDS)](https://bids-specification.readthedocs.io/) compatible datasets.
+
+This builds a [`image03.csv`](https://nda.nih.gov/data-structure/image03) data structure for upload with [nda-tools](https://github.com/NDAR/nda-tools) or [web uploader](https://nda.nih.gov/vt/). Data must first be organized in BIDS (see [bids-validator](https://bids-validator.readthedocs.io/en/stable/)) and [NDA's Global Unique IDentifiers](https://nda.nih.gov/nda/data-standards#guid) must have already been generated.
 
 ## Installation
 
@@ -24,15 +26,67 @@ Extract NIMH Data Archive compatible metadata from Brain Imaging Data Structure 
     optional arguments:
       -h, --help        Show this help message and exit.
 
+## Prerequisites
 
-## GUID_MAPPING file format
-The is the file format produced by the GUID Tool, one line per subject in the format:
+Here is an example directory tree. In addition to BIDS organized `.nii.gz` and `.json` files, you will also need a GUID mapping, participants, and scans file.
+```
+guid_map.txt # ** GUID_MAPPING file: id lookup
+BIDS/
+├── participants.tsv # ** Participants File: age, sex
+└── sub-10000
+    └── ses-1
+        ├── anat
+        │   ├── sub-10000_ses-1_T1w.json
+        │   ├── sub-10000_ses-1_T1w.nii.gz
+        ├── func
+        │   ├── sub-10000_ses-1_task-rest_bold.json
+        │   ├── sub-10000_ses-1_task-rest_bold.nii.gz
+        └── sub-10000_ses-1_scans.tsv # ** Scans File: acq_time->interview_date
+```
+
+
+### GUID_MAPPING file format
+The is the file format produced by the [GUID Tool](https://nda.nih.gov/nda/nda-tools#guid-tool), one line per subject in the format:
 
 `<participant_id> - <GUID>`
+
+It is not part of the BIDS specification. The file translates BIDS subject id into NDA participant id (GUID) and can be stored anywhere. Its location is explicitly given to the `bids2nda` command.
+
+### Participants File
+A [Participants File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#participants-file) is at the BIDS root like `BIDS/participants.tsv`. It should at least have columns `participant_id`, `age`, and `sex`.
+
+|col|desc|notes|
+|---|---|---|
+|`particiapnt_id` | like `sub-X` | does not include session label (See [Sessions File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#sessions-file). Not supported here) |
+|`age`            | number in years | converted to months for NDA's `interview_age`|
+|`sex` |||
+
+Contents could look like
+```
+participant_id	sex	age
+sub-100000  	M	46
+```
+
+### Scans File
+
+[Scans File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#scans-file) is at the session (or subject if session is omitted) level like `BIDS/sub-X/ses-1/sub-X_ses-1_scans.tsv`. It must have at least `filename` and `acq_time`.
+
+|col|desc|notes|
+|---|---|---|
+|`filename`| like `func/sub-X_bold.nii.gz` | relative to session root |
+|`acq_time`| date like `YYYY-MM-DD` | creates `interview_date` NDA column|
+
+
+Contents could look like
+```
+acq_time	filename
+2000-12-31	anat/sub-100000_ses-1_T1w.nii.gz
+2000-12-31	func/sub-100000_ses-1_task-rest_bold.nii.gz
+```
 
 ## Example outputs
 See [/examples](/examples)
 
 ## Notes:
-Column `'experiment_id'` must be manually filled in for now.
+Column `'experiment_id'` must be manually filled. For `_bold` suffixes, the value stored in the json sidecar with the key `ExperimentID` will be used.
 This is based on experiment IDs received from NDA after setting the study up through the NDA website [here](https://ndar.nih.gov/user/dashboard/collections.html).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # BIDS2NDA
 Extract [NIMH Data Archive](https://nda.nih.gov/) compatible metadata from [Brain Imaging Data Structure (BIDS)](https://bids-specification.readthedocs.io/) compatible datasets.
 
-This builds a [`image03.csv`](https://nda.nih.gov/data-structure/image03) data structure for upload with [nda-tools](https://github.com/NDAR/nda-tools) or [web uploader](https://nda.nih.gov/vt/). Data must first be organized in BIDS (see [bids-validator](https://bids-validator.readthedocs.io/en/stable/)) and [NDA's Global Unique IDentifiers](https://nda.nih.gov/nda/data-standards#guid) must have already been generated.
+This builds a [`image03.csv`](https://nda.nih.gov/data-structure/image03) data structure for upload with [nda-tools](https://github.com/NDAR/nda-tools) or [web uploader](https://nda.nih.gov/vt/).
+Data must first be organized in BIDS (see [bids-validator](https://bids-validator.readthedocs.io/en/stable/)) and [NDA's Global Unique IDentifiers](https://nda.nih.gov/nda/data-standards#guid) must have already been generated.
 
 ## Installation
 
@@ -50,15 +51,18 @@ The is the file format produced by the [GUID Tool](https://nda.nih.gov/nda/nda-t
 
 `<participant_id> - <GUID>`
 
-It is not part of the BIDS specification. The file translates BIDS subject id into NDA participant id (GUID) and can be stored anywhere. Its location is explicitly given to the `bids2nda` command.
+It is not part of the BIDS specification.
+The file translates BIDS subject id into NDA participant id (GUID) and can be stored anywhere.
+Its location is explicitly given to the `bids2nda` command.
 
 ### Participants File
-A [Participants File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#participants-file) is at the BIDS root like `BIDS/participants.tsv`. It should at least have columns `participant_id`, `age`, and `sex`.
+A [Participants File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#participants-file) is at the BIDS root like `BIDS/participants.tsv`.
+It should at least have columns `participant_id`, `age`, and `sex`.
 
 |col|desc|notes|
 |---|---|---|
 |`particiapnt_id` | like `sub-X` | does not include session label (See [Sessions File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#sessions-file). Not supported here) |
-|`age`            | number in years | converted to months for NDA's `interview_age`|
+|`age` | number in years | converted to months for NDA's `interview_age`|
 |`sex` |||
 
 Contents could look like
@@ -69,7 +73,8 @@ sub-100000  	M	46
 
 ### Scans File
 
-[Scans File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#scans-file) is at the session (or subject if session is omitted) level like `BIDS/sub-X/ses-1/sub-X_ses-1_scans.tsv`. It must have at least `filename` and `acq_time`.
+[Scans File](https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files.html#scans-file) is at the session (or subject if session is omitted) level like `BIDS/sub-X/ses-1/sub-X_ses-1_scans.tsv`. 
+It must have at least `filename` and `acq_time`.
 
 |col|desc|notes|
 |---|---|---|
@@ -88,5 +93,6 @@ acq_time	filename
 See [/examples](/examples)
 
 ## Notes:
-Column `'experiment_id'` must be manually filled. For `_bold` suffixes, the value stored in the json sidecar with the key `ExperimentID` will be used.
+Column `'experiment_id'` must be manually filled.
+For `_bold` suffixes, the value stored in the json sidecar with the key `ExperimentID` will be used.
 This is based on experiment IDs received from NDA after setting the study up through the NDA website [here](https://ndar.nih.gov/user/dashboard/collections.html).


### PR DESCRIPTION
Descriptions, examples, and references for participants.tsv and scans.tsv.
Update note: ExperimentID is read from json for bold.

Link to NDA image03 and GUID Tools, nda-tools, web uploader, bids-validator, and BIDS spec for required but BIDS-optional files.
