### PR TITLE
feat: NDA Experimental ID from tsv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Extract NIMH Data Archive compatible metadata from Brain Imaging Data Structure 
 
 
 ## Usage
+<!-- python3 -m bids2nda.main -h -->
 
-    usage: bids2nda [-h] [-v] BIDS_DIRECTORY GUID_MAPPING OUTPUT_DIRECTORY
+    usage: bids2nda [-h] [--experimentid_tsv EXPERIMENTID_TSV] BIDS_DIRECTORY GUID_MAPPING OUTPUT_DIRECTORY
 
     BIDS to NDA converter.
 
@@ -23,7 +24,8 @@ Extract NIMH Data Archive compatible metadata from Brain Imaging Data Structure 
 
     optional arguments:
       -h, --help        Show this help message and exit.
-
+      --experimentid_tsv EXPERIMENTID_TSV
+                        Path to TSV file w/cols ExperimentID and Pattern for NDA EID lookup
 
 ## GUID_MAPPING file format
 The is the file format produced by the GUID Tool, one line per subject in the format:
@@ -33,6 +35,30 @@ The is the file format produced by the GUID Tool, one line per subject in the fo
 ## Example outputs
 See [/examples](/examples)
 
-## Notes:
-Column `'experiment_id'` must be manually filled in for now.
+## ExperimentID
+
+### Sidecar
+The `image03` column `'experiment_id'` is required for fMRI (`_bold.nii.gz`) files.
 This is based on experiment IDs received from NDA after setting the study up through the NDA website [here](https://ndar.nih.gov/user/dashboard/collections.html).
+
+For `_bold` suffixes, the value stored in the json sidecar with the key `ExperimentID` will be used. That is, `sub-1_task-rest_bold.json` might look like
+```
+{
+ ...
+ "ExperimentID": "1234",
+}
+```
+
+### ExperimentID Pattern TSV
+If you do not want to modify existing sidecars, you can specify IDs based on file name patterns using a dedicated file.
+
+```
+bids2nda ... --experimentid_tsv eid_patt.txt
+```
+
+where `eid_patt.txt` might look like
+
+```
+ExperimentID    Pattern
+1234    task-rest
+```

--- a/bids2nda/experiment_id.py
+++ b/bids2nda/experiment_id.py
@@ -1,0 +1,44 @@
+"""
+NDA requires fMRI tasks have an Experiment ID.
+The simplest way to deal with this is
+populating the "ExperimentID" key in a _bold.json sidecar.
+
+But at the time of upload,
+it many be desirable to leave underlying dataset unmodified.
+This provides an alternative:
+match input filename against a set of patterns to set the ExperimentID.
+
+Patterns are imported from a tab separated text file.
+An EID can have many patterns (why? maybe for extra modalities?)
+"""
+
+import re
+
+import pandas as pd
+
+ExperimentID = str
+
+
+def read_experiment_lookup(tsv_fname: str) -> pd.DataFrame:
+    """
+    Read in TSV with columns 'ExperimentID' and 'Pattern'. Compile all patterns
+    """
+    df = pd.read_csv(tsv_fname, sep="\t", header=0)
+    if "ExperimentID" not in df.columns or "Pattern" not in df.columns:
+        raise ValueError(
+            f"Experiment ID pattern tsv lookup file '{tsv_fname}'"
+            + "must have columns 'ExperimentID' and 'Pattern'"
+        )
+    df["ExperimentID"] = [str(x) for x in df.ExperimentID]
+    df["Pattern"] = [re.compile(x) for x in df.Pattern]
+    return df
+
+
+def eid_of_filename(eid_lookup, filename: str) -> ExperimentID:
+    """
+    Try all patterns against filename to find a ExperimentID
+    """
+    for _, row in eid_lookup.iterrows():
+        if row.Pattern.search(filename):
+            return row.ExperimentID
+    return ""

--- a/tests/test_eid.py
+++ b/tests/test_eid.py
@@ -1,0 +1,95 @@
+"""
+Tests for matching Experiment ID to filenames
+"""
+
+import os
+import os.path
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from nibabel.testing import data_path as nibabel_data
+
+import bids2nda.main
+from bids2nda.experiment_id import eid_of_filename, read_experiment_lookup
+
+
+def test_ied_read_bad(tmpdir):
+    """errors with bad column"""
+    mockfile = StringIO("BadCol\tPattern\n123\ttask-rest\n")
+    with pytest.raises(ValueError, match="must have columns"):
+        read_experiment_lookup(mockfile)
+
+
+def test_ied_read():
+    """can read and use"""
+    mockfile = StringIO("ExperimentID\tPattern\n123\ttask-rest\n")
+    df = read_experiment_lookup(mockfile)
+    assert eid_of_filename(df, "sub-X/sub-X_task-rest_bold.nii.gz") == "123"
+    assert eid_of_filename(df, "sub-X_task-notrest_bold.nii.gz") == ""
+
+
+def test_full(tmpdir):
+    """
+    example run
+    """
+    # build example input -- TODO: create and use files in examples/
+    bids = tmpdir.join("in/sub-1/func/")
+    os.makedirs(bids)
+    os.symlink(
+        os.path.join(nibabel_data, "standard.nii.gz"),
+        bids.join("sub-1_task-rest_bold.nii.gz"),
+    )
+    with open(bids.join("sub-1_task-rest_bold.json"), "w") as f:
+        f.write('{"TaskName": "rest"}')
+
+    os.symlink(
+        os.path.join(nibabel_data, "standard.nii.gz"),
+        bids.join("sub-1_task-notrest_bold.nii.gz"),
+    )
+    with open(bids.join("sub-1_task-notrest_bold.json"), "w") as f:
+        f.write('{"TaskName": "notrest"}')
+
+    # age, gender, interview_age
+    with open(tmpdir.join("in/participants.tsv"), "w") as f:
+        f.write("participant_id\tsex\tage\nsub-1\tM\t100\n")
+    with open(tmpdir.join("in/sub-1/sub-1_scans.tsv"), "w") as f:
+        f.write(
+            "filename\tacq_time\n"
+            + "func/sub-1_task-rest_bold.nii.gz\t2020-12-31\n"
+            + "func/sub-1_task-notrest_bold.nii.gz\t2020-12-31\n"
+        )
+
+    guidmap = tmpdir.join("guidmap.txt")
+    with open(guidmap, "w") as f:
+        f.write("1 - NDARXXXX")
+
+    exptsv = str(tmpdir.join("expids.tsv"))
+    with open(exptsv, "w") as f:
+        f.write("ExperimentID\tPattern\n123\ttask-rest\n")
+
+    # run
+    sysargs = [
+        "bids2nda",
+        str(tmpdir.join("in")),
+        str(guidmap),
+        str(tmpdir.join("out")),
+        "--experimentid_tsv",
+        exptsv,
+    ]
+    with patch.object(sys, "argv", sysargs):
+        bids2nda.main.main()
+
+    # check output
+    # expect task-rest to have exp id 123
+    df = pd.read_csv(tmpdir.join("out/image03.txt"), skiprows=1, sep="\t")
+    example_with_eid = str(bids.join("sub-1_task-rest_bold.nii.gz"))
+    eid = df.experiment_id[df.image_file == example_with_eid].tolist()[0]
+    assert eid == 123
+
+    # "notrest" has no match. should be NaN (empty string)
+    example_without_eid = str(bids.join("sub-1_task-notrest_bold.nii.gz"))
+    eid = df.experiment_id[df.image_file == example_without_eid].tolist()[0]
+    assert pd.isna(eid)


### PR DESCRIPTION
I think the current `ExperimentID` in json sidecar solution is sufficient. But for our dataset, I do not want to update existing json file modification timestamps.  I suspect this might be an unusual case not worth the extra code maintenance burden, but leaving here just in case. (Maybe if ExperimentID needs to be assigned to other files w/o a sidecar?)

Similar to #37, this provides a new argument `--experimentid_tsv EXPERIMENTID_TSV`  to specify a tsv with `ExperimentID` and `Pattern` columns.

if `file` matches `Pattern`, the paired ExperimentID is added to the image03 dict.

When it exists, the JSON side car `ExperimentID` value is used instead of a pattern match.

Most of the changes are in their own new file [`bids2nda/experiment_id.py`](https://github.com/bids-standard/bids2nda/pull/47/files#diff-49947a87b310e7a036753251135a89b95593c317b3a1db27c40b8485c6163bc4) and tests in [tests/test_eid.py](https://github.com/bids-standard/bids2nda/pull/47/files#diff-144099fa6c73eb276ba532b75b5228d00a081e33d6793780f1b9fae3f7620f8f).

The PR includes unit and integration test.
The integration test uses `nibabel.data_dir / "standard.nii.gz"` for input. The files has `unknown` for the xyzt measurement. `units_dict` was updated to handle this.
